### PR TITLE
fix indentation in kubernetes_crio/http_server/full-cluster/k8s-http_server.yaml

### DIFF
--- a/kubernetes_crio/http_server/full-cluster/k8s-http_server.yaml
+++ b/kubernetes_crio/http_server/full-cluster/k8s-http_server.yaml
@@ -14,8 +14,8 @@ spec:
     ports:
     - containerPort: 1234
       protocol: TCP
-  livenessProbe:
-    tcpSocket:
-      port: 1234
-    initialDelaySeconds: 3
-    periodSeconds: 30
+    livenessProbe:
+      tcpSocket:
+        port: 1234
+      initialDelaySeconds: 3
+      periodSeconds: 30


### PR DESCRIPTION
Not much to say, just a minor change.

Signed-off-by: Sven Pfennig <s.pfennig@reply.de>