### PR TITLE
Remove -i to disable interaction and add /http_server.wasm

### DIFF
--- a/kubernetes_crio/http_server/http_server_application.sh
+++ b/kubernetes_crio/http_server/http_server_application.sh
@@ -9,7 +9,7 @@ sudo ./kubernetes/cluster/kubectl.sh config use-context local
 sudo ./kubernetes/cluster/kubectl.sh
 
 sudo ./kubernetes/cluster/kubectl.sh cluster-info
-sudo ./kubernetes/cluster/kubectl.sh run --restart=Never http-server --image=avengermojo/http_server:with-wasm-annotation --annotations="module.wasm.image/variant=compat" --overrides='{"kind":"Pod", "apiVersion":"v1", "spec": {"hostNetwork": true}}' /http_server.wasm
+sudo ./kubernetes/cluster/kubectl.sh run --restart=Never http-server --image=avengermojo/http_server:with-wasm-annotation --annotations="module.wasm.image/variant=compat" --overrides='{"kind":"Pod", "apiVersion":"v1", "spec": {"hostNetwork": true, "containers": {"livenessProbe": {"initialDelaySeconds": 3, "periodSeconds": 30, "tcpSocket": {"port": 1234}}}}}' /http_server.wasm
 # sudo ./kubernetes/cluster/kubectl.sh run -i --expose --port=1234 --restart=Never http-server --image=avengermojo/http_server:with-wasm-annotation --annotations="module.wasm.image/variant=compat" --overrides='{"kind":"Pod", "apiVersion":"v1", "spec": {"hostNetwork": true}}' /http_server.wasm
 
 echo -e "Pulling image from the docker hub..."

--- a/kubernetes_crio/http_server/http_server_application.sh
+++ b/kubernetes_crio/http_server/http_server_application.sh
@@ -9,8 +9,8 @@ sudo ./kubernetes/cluster/kubectl.sh config use-context local
 sudo ./kubernetes/cluster/kubectl.sh
 
 sudo ./kubernetes/cluster/kubectl.sh cluster-info
-# sudo ./kubernetes/cluster/kubectl.sh run --restart=Never http-server --image=avengermojo/http_server:with-wasm-annotation --annotations="module.wasm.image/variant=compat" --overrides='{"kind":"Pod", "apiVersion":"v1", "spec": {"hostNetwork": true}}'
-sudo ./kubernetes/cluster/kubectl.sh run -i --expose --port=1234 --restart=Never http-server --image=avengermojo/http_server:with-wasm-annotation --annotations="module.wasm.image/variant=compat" --overrides='{"kind":"Pod", "apiVersion":"v1", "spec": {"hostNetwork": true}}' /http_server.wasm
+sudo ./kubernetes/cluster/kubectl.sh run --restart=Never http-server --image=avengermojo/http_server:with-wasm-annotation --annotations="module.wasm.image/variant=compat" --overrides='{"kind":"Pod", "apiVersion":"v1", "spec": {"hostNetwork": true}}' /http_server.wasm
+# sudo ./kubernetes/cluster/kubectl.sh run -i --expose --port=1234 --restart=Never http-server --image=avengermojo/http_server:with-wasm-annotation --annotations="module.wasm.image/variant=compat" --overrides='{"kind":"Pod", "apiVersion":"v1", "spec": {"hostNetwork": true}}' /http_server.wasm
 
 echo -e "Pulling image from the docker hub..."
 sleep 60


### PR DESCRIPTION
My guess is the -i break the http_server, so remove it and hostnetwork is already using 127.0.0.1 so not need for expose port as well. 
Signed-off-by: Alex Lau (AvengerMoJo) <avengermojo@gmail.com>